### PR TITLE
Fix views.py for compatibility with mg 0.6.0 as of 2014-03-05

### DIFF
--- a/views.py
+++ b/views.py
@@ -68,7 +68,7 @@ def multi_submit_start(request):
             # Sniff the submitted media to determine which
             # media plugin should handle processing
             media_type, media_manager = sniff_media(
-              submitted_file)
+              submitted_file, filename)
     
             # create entry and save in database
             entry = new_upload_entry(request.user)


### PR DESCRIPTION
I've installed mediagoblin today from git master and got this error with this plugin:

```
2014-03-05 22:30:19,609 INFO    [mediagoblin.plugins.html5-multi-upload.views] html5-multi-upload: Got filename: example.jpg
Error - <type 'exceptions.TypeError'>: sniff_media() takes exactly 2 arguments (1 given)
URL: https://chno.de/m//html5-multi-upload/
File '/home/mediagoblin/mediagoblin/lib/python2.7/site-packages/Paste-1.7.5.1-py2.7.egg/paste/exceptions/errormiddleware.py', line 144 in __call__
  app_iter = self.application(environ, sr_checker)
File '/home/mediagoblin/mediagoblin/lib/python2.7/site-packages/Paste-1.7.5.1-py2.7.egg/paste/urlmap.py', line 203 in __call__
  return app(environ, start_response)
File '/home/mediagoblin/mediagoblin/mediagoblin/app.py', line 263 in __call__
  return self.call_backend(environ, start_response)
File '/home/mediagoblin/mediagoblin/mediagoblin/app.py', line 240 in call_backend
  response = controller(request)
File '/home/mediagoblin/mediagoblin/mediagoblin/decorators.py', line 45 in wrapper
  return controller(request, *args, **kwargs)
File '/home/mediagoblin/mediagoblin/mediagoblin/decorators.py', line 72 in new_controller_func
  return controller(request, *args, **kwargs)
File '/home/mediagoblin/mediagoblin/mediagoblin/plugins/html5-multi-upload/views.py', line 71 in multi_submit_start
  submitted_file)
TypeError: sniff_media() takes exactly 2 arguments (1 given)
```

My change fixed this.
